### PR TITLE
Backwards compatibility with template-haskell-2.5.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: haskell
 ghc:
+  - 7.0
   - 7.4
   - 7.6
   - 7.8


### PR DESCRIPTION
`th-reify-many` currently won't build on GHC 7.0 because it uses `template-haskell-2.5.0.0`, which represents typeclass instances as `ClassInstance` instead of `InstanceDec`. This commit uses CPP pragmas to select the right data type depending on which version of `template-haskell` is being used.
