### PR TITLE
Fix pattern-match warning on GHC 8.2

### DIFF
--- a/src/Language/Haskell/TH/ReifyMany.hs
+++ b/src/Language/Haskell/TH/ReifyMany.hs
@@ -111,6 +111,9 @@ reifyManyTyCons recurse = reifyMany recurse'
 #if MIN_VERSION_template_haskell(2,7,0)
             FamilyI{} -> skip "type or data family"
 #endif
+#if MIN_VERSION_template_haskell(2,12,0)
+            PatSynI{} -> skip "pattern synonym"
+#endif
 
 -- | Starting from a set of initial top level declarations, specified
 -- by @[Name]@, recursively enumerate other related declarations.  The


### PR DESCRIPTION
`template-haskell-2.12` added an `Info` constructor for pattern synonyms, so let's catch them here.